### PR TITLE
Replaced primes with prime powers.

### DIFF
--- a/src/api/actions.ts
+++ b/src/api/actions.ts
@@ -8,7 +8,7 @@ import {
   GeneratePdfCompleteAction,
   LOAD_EXAMPLES,
   LoadExamplesAction,
-  Prime,
+  PrimePower,
   REMOVE_ALL,
   REMOVE_IMAGE,
   RemoveAllAction,
@@ -25,7 +25,7 @@ export const appendImages = (images: CardImage[]): AppendImagesAction => ({
   payload: images,
 });
 
-export const generatePdf = (n: Prime): GeneratePdfAction => ({
+export const generatePdf = (n: PrimePower): GeneratePdfAction => ({
   type: GENERATE_PDF,
   payload: { n },
 });

--- a/src/api/lib.ts
+++ b/src/api/lib.ts
@@ -6,24 +6,26 @@ import random from 'lodash/random';
 import shuffle from 'lodash/shuffle';
 import { JSONSchemaBridge } from 'uniforms-bridge-json-schema';
 
-import { CardImage, CardSymbol, Prime, Settings } from './types';
+import { CardImage, CardSymbol, PrimePower, Settings } from './types';
 
 /**
  * Generate supported plains (dimensions) according to the Ray-Chaudhuri–Wilson theorem
- * n - prime number
+ * n - prime power
  * @see https://math.stackexchange.com/questions/36798/what-is-the-math-behind-the-game-spot-it
  */
-export const plains = ([2, 3, 5, 7, 11] as Prime[]).map((n: Prime) => ({
-  n,
-  symbols: n ** 2 + n + 1,
-  symbolsPerCard: n + 1,
-}));
+export const plains = ([2, 3, 4, 5, 7, 8, 9, 11] as PrimePower[]).map(
+  (n: PrimePower) => ({
+    n,
+    symbols: n ** 2 + n + 1,
+    symbolsPerCard: n + 1,
+  }),
+);
 
 /**
  * Generate unique cards for available plains
  * @see https://math.stackexchange.com/questions/1303497/what-is-the-algorithm-to-generate-the-cards-in-the-game-dobble-known-as-spo
  */
-export const generateCards = (n: Prime): number[][] => {
+export const generateCards = (n: PrimePower): number[][] => {
   const d = [...Array(n).keys()];
 
   return shuffle([
@@ -70,7 +72,7 @@ export const sleep = (t = 0): Promise<never> =>
  */
 export const generatePdf = async (
   images: CardImage[] = [],
-  options: { n: Prime } & Settings,
+  options: { n: PrimePower } & Settings,
 ): Promise<JsPDF> => {
   const {
     n, // No of plains

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -16,7 +16,7 @@ export const UPLOAD_IMAGES = 'UPLOAD_IMAGES';
 export const SET_SETTINGS = 'SET_SETTINGS';
 
 // Payload types
-export type Prime = 2 | 3 | 5 | 7 | 11;
+export type PrimePower = 2 | 3 | 4 | 5 | 7 | 8 | 9 | 11;
 
 export interface Settings {
   pageWidth: number; // Page width in mm
@@ -51,7 +51,7 @@ export interface AppendImagesAction {
 export interface GeneratePdfAction {
   type: typeof GENERATE_PDF;
   payload: {
-    n: Prime;
+    n: PrimePower;
   };
 }
 


### PR DESCRIPTION
The implemented algorithm to construct a card set does not only work for prime numbers, but also for all other prime powers (e.g. 2^2=4, 2^3=8, 3^2=9).
I therefore added them and renamed the type accordingly.
